### PR TITLE
Add timestamp to PS1

### DIFF
--- a/.bashrc
+++ b/.bashrc
@@ -2,7 +2,7 @@
 parse_git_branch() {
      git branch 2> /dev/null | sed -e '/^[^*]/d' -e 's/* \(.*\)/ (\1)/'
 }
-export PS1="\[\033[35m\][\u@\h] \[\033[36m\]\w\[\033[33m\]\$(parse_git_branch)\[\033[00m\] $ "
+export PS1="$(date "+%H:%M:%S ")\[\033[35m\][\u@\h] \[\033[36m\]\w\[\033[33m\]\$(parse_git_branch)\[\033[00m\] $ "
 
 # Infinite history: https://stackoverflow.com/questions/9457233/unlimited-bash-history
 # ---------------------


### PR DESCRIPTION
I found lost sometimes especially when debugging while scrolling up in my history to see when I ran a certain command.

Putting the timestamp in PS1 helps contextualize the history w.r.t time.